### PR TITLE
2024-03-15 앱

### DIFF
--- a/InSange/DP/7579.cpp
+++ b/InSange/DP/7579.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+vector<int> memory;	// DP 저장 메모리
+vector<int> app;			// 앱 실행 크기
+vector<int> cost;			// 앱 비활성시 드는 비용
+int N, M, costSum;		//	N:개수, M:필요한 메모리
+
+void Input()
+{
+	costSum = 0;			// 모든 앱 비활성시 드는 최대 크기로 설정해주기 위해 0으로 초기화
+	cin >> N >> M;
+	// N개의 크기만큼 앱 실행 크기 추가
+	int n;
+	for (int i = 0; i < N; i++)
+	{
+		cin >> n;
+		app.push_back(n);
+	}
+	// N개의 비활성시 드는 비용 추가
+	for (int i = 0; i < N; i++)
+	{
+		cin >> n;
+		cost.push_back(n);
+		costSum += n;
+	}
+	//	DP 크기를 모든 앱 비활성시 발생할 수 있는 가능 크기만큼 0으로 할당해서 초기화해준다.
+	memory.assign(costSum+1, 0);
+}
+
+int Solve()
+{
+	for (int i = 0; i < N; i++)
+	{	// 최대 비용에서 0으로 탐색을 하면서 모든 가능성에서 최소의 가능성으로 점점 좁혀나간다.
+		// 이렇게 진행하게 되면 최소의 비용(적은 비활성화)를 찾으면서 M보다 크거나 같은 메모리양들을 적재할 수 있다.
+		for (int j = costSum; j >= 0; j--)
+		{	// 현재 비용(cost[i])보다 남은 비용(j)이 작다면 그 아래의 있는 값도 할당 못해줌. 바로 탈출.
+			if (cost[i] > j) break;
+			// (현재의 저장해둔 메모리 비용)과 (현재 비용을 뺀 나머지 비용 + 현재 비용)을 비교하여 더 큰 메모리로 교체해준다.
+			memory[j] = max(memory[j], memory[j - cost[i]] + app[i]);
+		}
+	}
+
+	for (int i = 0; i <= costSum; i++)
+	{	// 메모리(DP)의 인덱스는 비활성하는 비용의 크기를 나타낸다. 0->costSum을 돌아보면서 M보다 크거나 같은(조건 충족) 인덱스를 찾아 반환한다.
+		if (memory[i] >= M) return i;
+	}
+}
+
+int main()
+{
+	cin.tie(nullptr);
+	ios::sync_with_stdio(false);
+
+	Input();
+	cout <<  Solve();
+
+	return 0;
+}

--- a/InSange/README.md
+++ b/InSange/README.md
@@ -2,6 +2,7 @@
 
 | 차시 |    날짜    | 문제유형 | 링크 | 풀이 |
 |:----:|:---------:|:----:|:-----:|:----:|
-| 1차시 | 2024.03.11 |  BFS  | [숨바꼭질 4](https://www.acmicpc.net/problem/13913)  | - |
+| 1차시 | 2024.03.11 |  BFS  | [숨바꼭질 4](https://www.acmicpc.net/problem/13913)  | [#1](https://github.com/AlgoLeadMe/AlgoLeadMe-8/pull/3) |
+| 2차시 | 2024.03.15 |  DP  | [앱](https://www.acmicpc.net/problem/7579)  | - |
 =======
 ---


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[앱](https://www.acmicpc.net/problem/7579)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
10시간

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
우리가 알고 있던 DP 배낭 문제랑 비슷했습니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/51250442/70eb712a-0219-4451-a5e2-c27f311cb06c)

### 첫번째 접근
1. ```메모리 바이트(M)```를 기준으로 나열한다.
2. 모든 ```앱(N)```들을 방문하면서 메모리마다 돌아본다.
3. M값을 충족하는 최소 비용을 반환한다.

해당 방법으로 ```메모리 바이트(M)```를 기준으로 접근하였을 때 
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/51250442/2b96d1ea-3cb0-4706-b0e1-7dd46e78338c)
메모리(M)는 최소 1에서 10,000,000만큼 나열이되어야하고
앱(N)은 최소 1개에서 100까지 존재하기에 만약 모든 메모리 바이트를 앱들이 돈다고 가정하였을 경우
100 * 10,000,000 만큼 돌아야하며 시간 복잡도 및 메모리 초과 문제가 발생할 수 있다.

### 두번째 접근
1. ```비용(c)```를 기준으로 나열한다.
2. 모든 ```비용(c)```를 더한 값을 최대 크기로 지정한다.
3. 비용을 기점으로 ```앱 메모리(m)```를 배열에 할당하여 현재 비용을 뺀 값에 ```앱 메모리(m)```을 더한 값과 현재 메모리 비용을 비교한다.
4. 소모되는 '''비용(c)''' 값보다 할당해준 비용이 작을 경우를 대비하여 최대 비용에서 0으로 접근하게 끔 한다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/51250442/2d73b7de-3853-4e57-9243-75addb63bfd9)
```비용(c)```를 기준으로 나열했을 경우 ```앱(N)``` 개수 만큼 비교가 더해진다 했을 때 100*100 만큼의 메모리 비용이 필요하다.

![image](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/51250442/f3e62dd2-9692-4dbb-8aa3-e17dfda64088)


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
참고 블로그 :https://wisdom-990629.tistory.com/entry/C-%EB%B0%B1%EC%A4%80-7579%EB%B2%88-%EC%95%B1