### PR TITLE
5-yuyu0830

### DIFF
--- a/yuyu0830/탐색/2239.cpp
+++ b/yuyu0830/탐색/2239.cpp
@@ -1,0 +1,68 @@
+// 백트래킹 골드 4 스도쿠 https://www.acmicpc.net/problem/2239
+#include <iostream>
+
+using namespace std;
+
+int sudoku[9][9] = {0, 0};
+
+bool solve(int pos) {
+    // 마지막 칸 순회중이면 true 리턴
+    if (pos == 81) return true;
+
+    // pos 값 통해 x, y 값 추출
+    int x = pos % 9;
+    int y = pos / 9;
+
+    // 현재 탐색 위치에 값이 있으면 바로 다음 탐색
+    if (sudoku[y][x]) {
+        if (solve(pos + 1)) return true;
+        return false;
+    }
+
+    // 3x3 칸 탐색을 위한 포지션 값
+    int sx = (x / 3) * 3;
+    int sy = (y / 3) * 3;
+
+    // 1~9까지 겹치는 수가 없는지 체크
+    for (int i = 1; i <= 9; i++) {
+        bool flag = true;
+
+        // 가로, 세로, 3x3 칸 탐색
+        for (int j = 0; j < 9; j++) {
+            if (sudoku[j][x] == i || sudoku[y][j] == i || sudoku[sy + (j / 3)][sx + (j % 3)] == i) {
+                // 겹치는게 있는 경우
+                flag = false;
+                break;
+            }
+        }
+
+        // 가로, 세로, 3x3 칸 탐색이 무사히 종료된 경우
+        if (flag) {
+            sudoku[y][x] = i;
+            if (solve(pos + 1)) return true;
+            sudoku[y][x] = 0;
+        }
+    }
+
+    return false;
+}
+
+int main() {
+    // Input
+    for (int i = 0; i < 9; i++) {
+        char str[10]; cin >> str;
+        for (int j = 0; j < 9; j++) {
+            sudoku[i][j] = str[j] - 48;
+        }
+    }
+
+    solve(0);
+
+    // Output
+    for (int i = 0; i < 9; i++) {
+        for (int j = 0; j < 9; j++) {
+            printf("%d", sudoku[i][j]);
+        }
+        printf("\n");
+    }
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
[스도쿠](https://www.acmicpc.net/problem/2239)


## ✔️ 소요된 시간
1시간

## ✨ 수도 코드
비어있는 스도쿠를 채우는 문제입니다. 하지만 스도쿠의 칸이 많이 비어있어 여러가지 답이 나올 수 있는 문제입니다. 따라서 문제의 *답이 여러 개 있다면 그 중 사전식으로 앞서는 것을 출력한다. 즉, 81자리의 수가 제일 작은 경우를 출력한다.* 에 맞게끔 출력하면 됩니다.

어떤 식으로 풀까 고민하던 중 위의 *사전식으로 앞서는 것* 이라는 부분에서 아이디어를 얻었습니다. 앞에서부터 1~9까지 대입하며 백트래킹으로 탐색하면 되겠구나 싶었습니다.

제일 `첫번째 칸`부터 `81번째 칸` 까지 재귀함수를 통해 탐색(DFS) 합니다. 해당 칸이 숫자가 있다면 다음 칸을 탐색, 없다면 해당 칸을 탐색합니다.

solve 함수를 통해 해당 칸에 들어갈 수 있는 숫자를 체크하고, 탐색합니다. 스도쿠의 룰 상 같은 가로, 세로 줄에 같은 숫자가 있으면 안되고, 9x9 보드를 9개의 3x3으로 칸을 나눴을 때, 현재 탐색 중인 칸이 속한 3x3 칸에서도 같은 숫자가 있으면 안됩니다. 2중 for문을 통해 현재 탐색하는 칸에 `숫자 i` 가 겹치는게 없는지 `j` 를 통해 체크합니다. 만약 문제가 없다면 현재 칸에 `i`를 넣은 채로 다음 칸을 탐색합니다. 만약 겹친다면 `i` 는 넘어갑니다.

for문이 종료될 때까지 정답이 없었다면 현재의 스도쿠 상태로는 답이 나올 수 없는 상태이기 때문에 `false`를 리턴합니다. 만약 82번째 칸을 탐색, 즉 마지막 칸까지 채워졌다면 `true`를 리턴합니다. 각 재귀 함수에서 `true`가 리턴되면 바로바로 `true`를 리턴해 재귀를 종료합니다.

## 📚 새롭게 알게적된 내용
처음 문제를 봤을 때는 탐색이 시간 내로 종료될 수 있을까? 시간 초과 나오지 않을까? 싶었는데 다 풀고 생각해보니 스도쿠 룰 상 진행될 수록 탐색이 제한되기 때문에 빈 칸이 어느정도 있더라도 탐색 횟수가 그리 많지는 않다.
