### PR TITLE
9-yuyu0830

### DIFF
--- a/yuyu0830/정렬/23970.cpp
+++ b/yuyu0830/정렬/23970.cpp
@@ -1,0 +1,58 @@
+#include <iostream>
+
+#define fastio cin.tie(NULL); cin.sync_with_stdio(false);
+
+using namespace std;
+
+int arr[2][10001] = {0, };
+int n, arrPtr = 0;
+
+bool same() {
+    // start at 'arrPtr'
+    for (int i = arrPtr; i < n; i++) {
+        // if diff, terminate this function
+        if (arr[0][i] != arr[1][i]) return false;
+        // if same, then that index will same forever. no reason to compare again.
+        arrPtr++;
+    }
+    return true;
+}
+
+int main() {
+    fastio 
+    cin >> n;
+    for (int i = 0; i < 2; i++) 
+        for (int j = 0; j < n; j++) 
+            cin >> arr[i][j];
+        
+    int rnd = n - 1, ptr = 0;
+
+    // it can be same before sort
+    if (same()) {
+        printf("1\n");
+        return 0;
+    }
+
+    while (rnd) {
+        // sort [0] to [ptr - rnd]
+        int a = arr[0][ptr];
+        int b = arr[0][ptr + 1];
+
+        arr[0][ptr] = min(a, b);
+        arr[0][ptr + 1] = max(a, b);
+
+        // if this index is last index in this round
+        if (++ptr == rnd) {
+            // next round
+            ptr = 0;
+            rnd--;
+        }
+
+        if (same()) {
+            // if arr is same
+            printf("1\n");
+            return 0;
+        }
+    }
+    printf("0\n");
+}


### PR DESCRIPTION
## 🔗 문제 링크
[알고리즘 수업 - 버블 정렬 3](https://www.acmicpc.net/problem/23970)
## ✔️ 소요된 시간
1시간

## ✨ 수도 코드
### 문제 이해
`n`의 길이를 가진 `수열 a, b`가 주어진다. `a`를 버블 정렬 하려고 할 때, 중간에 `b`와 같아지는 순간이 생기는지 생기지 않는지 여부를 1, 0으로 출력하자

- 5 ≤ n ≤ 10,000

### 문제 풀이
처음에는 이거 직접 버블 정렬 하면서 일일이 비교하면 시간이 말이 되나...? 싶었다. 버블 정렬은 무조건 `n * (n - 1) / 2` 번 연산할텐데? 싶어서 최대 경우의 수를 계산 해보니 약 5000만번... 여기에 매 정렬마다 10,000개씩 비교한다고 하면 무조건 시간 초과가 나겠다 싶었다.

일단 시간 초과가 나든 말든 한번 맨땅 헤딩부터 해보자는 마음으로 간단히 버블 정렬을 구현하고 매 번 배열을 처음부터 끝까지 비교하는 코드를 짰다.

```cpp
bool same() {
    for (int i = 0; i < n; i++) 
        if (arr[0][i] != arr[1][i]) return false;
    return true;
}

while (rnd) {
    // sort [0] to [ptr - rnd]
    int a = arr[0][ptr];
    int b = arr[0][ptr + 1];

    arr[0][ptr] = min(a, b);
    arr[0][ptr + 1] = max(a, b);

    // if this index is last index in this round
    if (++ptr == rnd) {
        // next round
        ptr = 0;
        rnd--;
    }

    if (same()) {
        // if arr is same
        printf("1\n");
        return 0;
    }
}
```

돌려보니 이게 웬걸 중간까지 잘 가다가 시간 초과가 났다. 로직 자체는 문제가 없고 시간을 줄일 필요가 있는 케이스가 있다는 뜻이였다. 코드를 찬찬히 살펴보며 고민하던 중 아까 생각했던 **"매번 처음부터 비교하면 너무 오래 걸릴 것 같은데"** 라는 고민이 떠올랐고, 정렬되는 배열의 특징 상 앞부분이 같다면 그 앞부분은 정렬할 필요가 없다는 걸 깨달았다.

1. 만약 정렬 하는 도중 같아지는 경우의 수가 생긴다면 앞의 이미 같은 부분은 다시 비교할 필요가 없다.
2. 만약 같아지는 경우의 수가 없다고 해도 굳이 앞의 부분을 다시 비교할 필요가 없다. 어차피 중간부터 같아질 일이 없을테니까.

그래서 `same()` 함수만 조금 손봤다. 이렇게 하면 배열 비교를 정말 최악의 경우에도 5,000만(정렬 후 함수 호출) + 1만번(비교) 수행하게 된다!

```cpp
bool same() {
    // start at 'arrPtr'
    for (int i = arrPtr; i < n; i++) {
        // if diff, terminate this function
        if (arr[0][i] != arr[1][i]) return false;
        // if same, then that index will same forever. no reason to compare again.
        arrPtr++;
    }
    return true;
}
```

## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
우연히 지나가다 본 문제라서 풀어봤는데 정렬 다시 공부 해야겠구나 느꼈다..