### PR TITLE
10-seongwon030

### DIFF
--- a/seongwon030/수학/연속 합.py
+++ b/seongwon030/수학/연속 합.py
@@ -1,0 +1,20 @@
+import math
+
+n = int(input())
+for i in range(n):
+    cnt = 0
+    k = int(input())
+    j = 2 # 적어도 2개 이상의 연속된 자연수의 합
+    while True:
+        center_first = math.floor(k / j)  # center 값을 초기화
+        div = j // 2
+        if center_first < div:
+          break
+        if j % 2 == 0:
+            if ((center_first + center_first + 1) * div == k):
+                cnt += 1
+        elif j % 2 == 1:
+            if ((center_first * 2 * div + center_first) == k):
+                cnt += 1
+        j += 1
+    print(cnt)


### PR DESCRIPTION
## 🔗 문제 링크
[연속 합](https://www.acmicpc.net/problem/2737)

## 문제 
대부분의 양의 정수는 적어도 2개 이상의 연속된 자연수의 합으로 나타낼 수 있다.

예를 들면 다음과 같다.

6 = 1 + 2 + 3

9 = 5 + 4 = 4 + 3 + 2

하지만, 8은 연속된 자연수 합으로 나타낼 수가 없다.

자연수 N이 주어졌을 때, 이 수를 적어도 2개 이상의 연속된 자연수의 합으로 나타낼 수 있는 경우의 수를 출력하시오.

## ✔️ 소요된 시간
1시간 30분

## ✨ 수도 코드
연속합이니까 어디까지 탐색을 해야할까 고민을 해봤다. <code>제곱근</code>부터 생각해봤는데 n=1800 일 때 제곱근이 42..xx였다. 근데 1800을 45로 나눈 몫이 40이고 , 그렇다면 40을 기준 양옆으로 22개씩 연속합을  계산해도 연속합에 포함되는 값이 턱없이 많이 남는다. 

### 해결
나누는 수를 j , 나눈 몫을 center 라고 하면 <code>j는 연속합 구간의 정수의 개수</code>를 의미한다. <code>center는 그 구간의 중앙값</code>을 의미한다. center값은 소수점자리를 없애버리고 정수로 설정해줬다. <code>cnt는 경우의 수</code>다. (j//2 는 중앙값을 기준으로 양옆으로 더할 정수의 개수가 된다.)
1. j가 짝수일 때 -> center가 중앙값이 아니므로 연속합은 (center + center+1) x (j를 2로 나눈 몫) 
2. j가 홀수일 때 -> center가 중앙값이므로  center + center x 2 x (j//2) 
제일 중요한 것은 <code>어디까지 탐색해야 되는가</code> 인데 center 기준으로 <code>앞으로 j//2 번째까지 탐색이 가능해야 하니</code> center가 j//2보다 작기 전까지 반복하면 된다!
```python
import math

n = int(input())
for i in range(n):
    cnt = 0
    k = int(input())
    j = 2 # 적어도 2개 이상의 연속된 자연수의 합
    while True:
        center = math.floor(k / j)  # center 값을 초기화
        div = j // 2
        if center < div:
          break
        if j % 2 == 0:
            if ((center + center + 1) * div == k):
                cnt += 1
        elif j % 2 == 1:
            if ((center * 2 * div + center) == k):
                cnt += 1
        j += 1
    print(cnt)

```
  
<img width="845" alt="스크린샷 2024-05-07 00 42 38" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/105052068/596fa92d-006d-47ee-8aaa-86be993355cd">

## 📚 새롭게 알게된 내용
어디까지 탐색해야 하는지 집중하니 생각보다 빨리 풀리는 것 같다. 
