### PR TITLE
13-dhlee777

### DIFF
--- a/dhlee777/dp/구간합구하기5.cpp
+++ b/dhlee777/dp/구간합구하기5.cpp
@@ -1,0 +1,23 @@
+#include<iostream>
+using namespace std;
+int dp[1025][1025];
+int main(void) {
+	ios_base::sync_with_stdio(false);
+	cin.tie(NULL);
+	int size, cnt, start_row, start_col, end_row, end_col,temp;
+	cin >> size >> cnt;
+
+	for (int i = 1; i <=size; i++) {
+		for (int j = 1; j <=size; j++) {
+			cin >> temp;
+			dp[i][j] = dp[i - 1][j] + dp[i][j - 1] - dp[i - 1][j - 1] + temp;
+		}
+	}
+	for (int k = 0; k < cnt; k++) {
+		cin >> start_row >> start_col >> end_row >> end_col;
+		cout << dp[end_row][end_col] - dp[start_row - 1][end_col] - dp[end_row][start_col - 1] + dp[start_row - 1][start_col - 1];
+		cout << "\n";
+	}
+
+	return 0;
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[구간합구하기5](https://www.acmicpc.net/problem/11660)
## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
하루
## 첫번째풀이
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
``` cpp
#include<iostream>
using namespace std;
int a[1025][1025];
int sum = 0;
int section_sum(int start_row, int start_col, int end_row, int end_col) {
	for (int i = start_row; i <= end_row;i++) {
		for (int j = start_col; j <=end_col; j++) {
			 sum += a[i][j];
		}
	}
	return sum;
}
int main(void) {
	ios_base::sync_with_stdio(false);
	cin.tie(NULL);
	int size, cnt, start_row, start_col, end_row, end_col;
	cin >> size >> cnt;

	for (int i = 1; i <=size; i++) {
		for (int j = 1; j <=size; j++) {
			cin >> a[i][j];
		}
	}
	for (int k = 0; k < cnt; k++) {
		cin >> start_row >> start_col >> end_row >> end_col;
		cout<<section_sum(start_row, start_col, end_row, end_col)<<"\n";
		sum = 0;
	}
}
```
첫번째풀이는` 배열`을통해 표를입력받고 무식하게 `구간합의 범위가 들어올때마다 for루프문을통해 구간의 범위를 다 탐색하며 합을 계산`해주었다. 이랬더니 최악의 경우 `O(cnt*size^2)`의 시간복잡도가 발생한다. 이 경우 `연산의 최대횟수(cnt)`가 **100,000**까지 인걸 감안하면 엄청난 시간복잡도가 든다. 그래서  다른방법들을 찾아보다 `dp`를 이용하여 풀게되었다.
## 두번쨰풀이
``` cpp
#include<iostream>
using namespace std;
int dp[1025][1025];
int main(void) {
	ios_base::sync_with_stdio(false);
	cin.tie(NULL);
	int size, cnt, start_row, start_col, end_row, end_col,temp;
	cin >> size >> cnt;

	for (int i = 1; i <=size; i++) {
		for (int j = 1; j <=size; j++) {
			cin >> temp;
			dp[i][j] = dp[i - 1][j] + dp[i][j - 1] - dp[i - 1][j - 1] + temp;
		}
	}
	for (int k = 0; k < cnt; k++) {
		cin >> start_row >> start_col >> end_row >> end_col;
		cout << dp[end_row][end_col] - dp[start_row - 1][end_col] - dp[end_row][start_col - 1] + dp[start_row - 1][start_col - 1];
		cout << "\n";
	}

	return 0;
}
```
이풀이에서는 **dp[i][j]를 1행1열에서 i행j열까지의 부분합**이라고 정의해주었다. 그리고 값을 저장해줬다 재활용해주기 위해
점화식을 **dp[i][j]=dp[i-1][j]+dp[i][j-1]-dp[i-1][j-1]+temp(입력받은값)** 으로 세워줬다.

![KakaoTalk_20240523_121554288_01](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/117627976/2afb0bfe-8476-443d-af94-efd737267e71)

위와같은 배열에서 `dp[3][3]`을 구하려면 점화식과 같이 `파랑색 뭉치 2개`를더해주고 `중복되는구간(빨간색칠)`을빼준다 그리고 `입력받은값인 6`을 더해준다. `for루프문`을 통해 배열의 크기만큼` dp`값을 다 설정해줬으면 이제  `구간합`을구하기위해 `start_row(시작행),start_col(시작열),end_row(끝행),end_col(끝열)`을 받은뒤

![KakaoTalk_20240523_121554288_02](https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/117627976/3ea18863-02bd-4e89-bcf1-c3e75393aba2)
만약 `네모박스가 있는 6에서 3까지의 부분합(6,5,2,5,2,3)`을 구하고자한다면 `dp[끝행][끝열](빨간색네모)-dp[시작행-1][끝열](가로파란색부분)-dp[끝행][시작열-1](세로파란색부분)+dp[시작행-1][시작열-1](중복된빨간색부분) `의 식을 실행해주면 구하고자하는 값인 부분합을 구할 수 있다. 이 경우 표를입력받을때 dp값을 바로 설정해줌으로써 하나의 부분합을 구할때`O(1)`로 처리가 가능하다 따라서 전체 시간복잡도는 `O(size^2)`이 된다.
## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
dp로푸는 방법은` 점화식`을 세울 방법이 떠오르지않아[블로그](https://hagisilecoding.tistory.com/123)를 참고했다. 