### PR TITLE
14-yuyu0840

### DIFF
--- a/yuyu0830/수학/17387.cpp
+++ b/yuyu0830/수학/17387.cpp
@@ -1,0 +1,140 @@
+#include <iostream>
+#include <cmath>
+
+#define YES printf("1\n")
+#define NO printf("0\n")
+
+#define ERR_RANGE 1e-8
+
+using namespace std;
+
+struct Point {
+    double x, y;
+    void v(int _x, int _y) {
+        x = (double) _x;
+        y = (double) _y;
+    };
+
+    bool operator==(const Point &a) {
+        return (fabs(x - a.x) < ERR_RANGE) && (fabs(y - a.y) < ERR_RANGE);
+    }
+};
+
+struct Line {
+    Point a, b;
+    double gradient = 0.f, intercept = 0.f;
+    bool isInf = 0, isZero = 0;
+
+    void set() {
+        int x1, x2, y1, y2;
+        cin >> x1 >> x2 >> y1 >> y2;
+
+        // order by x
+        x1 < y1 ? a.v(x1, x2) : a.v(y1, y2);
+        x1 < y1 ? b.v(y1, y2) : b.v(x1, x2);
+
+        // if gradient is Zero
+        if (fabs(a.y - b.y) < ERR_RANGE) isZero = 1;
+
+        // if gradient is Infinite
+        else if (fabs(a.x - b.x) < ERR_RANGE) {
+            isInf = 1;
+            intercept = a.x;
+        }
+
+        else {
+            gradient = (a.y - b.y) / (a.x - b.x);
+            intercept = a.y - gradient * a.x;
+        }
+    }
+
+    bool isPointIn(Point p) {
+        bool ex = (p.x + ERR_RANGE >= a.x) && (p.x - ERR_RANGE <= b.x);
+        double sy = fmin(a.y, b.y), by = fmax(a.y, b.y);
+        bool ey = (p.y + ERR_RANGE >= sy) && (p.y - ERR_RANGE <= by);
+
+        return ex && ey;
+    }
+
+    void operator=(const Line &l) {
+        a = l.a;
+        b = l.b;
+        gradient = l.gradient;
+        intercept = l.intercept;
+        isZero = l.isZero;
+        isInf = l.isInf;
+    }
+};
+
+bool overlapCheck(Line a, Line b) {
+    if (a.a == b.a || a.b == b.a || a.a == b.b || a.b == b.b) {
+        YES;
+        return true;
+    }
+
+    if (a.isInf && b.isInf) {
+        double asy = fmin(a.a.y, a.b.y), aby = fmax(a.a.y, a.b.y);
+        double bsy = fmin(b.a.y, b.b.y), bby = fmax(b.a.y, b.b.y);
+        (fabs(a.intercept - b.intercept) < ERR_RANGE) && ((asy <= bby) != (aby <= bsy)) ? YES : NO;
+        return true;
+    }
+
+    if (a.isZero && b.isZero)  {
+        (fabs(a.a.x - b.a.x) < ERR_RANGE) && ((a.a.x <= b.b.x) != (a.b.x <= b.a.x)) ? YES : NO;
+        return true;
+    }
+
+    if (a.gradient && fabs(a.gradient - b.gradient) < ERR_RANGE) {
+        ((a.a.x <= b.b.x) != (a.b.x <= b.a.x)) && (fabs(a.intercept - b.intercept) < ERR_RANGE) ? YES : NO;
+        return true;
+    }
+
+    return false;
+}
+
+Point getIntersection(Line a, Line b) {
+    Point ret;
+
+    if (a.isInf || b.isInf) {
+        Line i = a.isInf ? a : b;
+        Line j = a.isInf ? b : a;
+
+        ret.x = i.intercept;
+        ret.y = j.isZero ? j.a.y : j.gradient * ret.x + j.intercept;
+    }
+
+    else if (a.isZero || b.isZero) {
+        Line i = a.isZero ? a : b;
+        Line j = a.isZero ? b : a;
+
+        ret.y = i.a.y;
+        ret.x = (ret.y - j.intercept) / j.gradient;
+    }
+    
+    else {
+        ret.x = -((a.intercept - b.intercept) / (a.gradient - b.gradient));
+        ret.y = a.gradient * ret.x + a.intercept;
+    }
+
+    return ret;
+}
+
+int main() {
+    Line a, b;
+
+    a.set();
+    b.set();
+
+    //printf("a : (%.0f, %.0f), (%.0f, %.0f), %.3f, %.3f, %d, %d\n", a.a.x, a.a.y, a.b.x, a.b.y, a.gradient, a.intercept, a.isInf, a.isZero);
+    //printf("b : (%.0f, %.0f), (%.0f, %.0f), %.3f, %.3f, %d, %d\n", b.a.x, b.a.y, b.b.x, b.b.y, b.gradient, b.intercept, b.isInf, b.isZero);
+    
+    // if two line's gradient is same
+    if (overlapCheck(a, b)) return 0;
+
+    Point p = getIntersection(a, b);
+
+    //printf("intersecion point : %.3f, %.3f\n", p.x, p.y);
+
+    // is intersection point on both line?
+    a.isPointIn(p) && b.isPointIn(p) ? YES : NO;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[선분 교차 2](https://www.acmicpc.net/problem/17387)

## ✔️ 소요된 시간
3일 (무려 67트..)
 
<img width="440" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/83621666/a1bab933-ed42-4c06-93b1-39e8ed3c9e34">
<img width="440" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/83621666/e1d57733-420b-4f6d-a57f-8ffd2db8133a">
<img width="440" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/83621666/a7486f5b-6ceb-4e7d-9ddb-816a46aad024">
<img width="440" alt="image" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/83621666/90b461ff-0c7f-438b-874c-bce43f6dbfd8">

(아찔)

## ✨ 수도 코드
### ❓ 문제
선분 2개가 (x1, x2), (y1, y2), (a1, a2), (b1, b2) 의 형태로 주어진다. 이 때 이 선분이 교차하는지 교차하지 않는지 판단하자. (점에서 만나는 경우도 겹치는 것이다.)

### ❗ 풀이
#### 해결 알고리즘
사실 처음 봤을때 너무 쉬워보였다. 다양한 방법이 떠올랐고, 예외도 그렇게 많이 떠오르진 않았다. 해결 방식은 **"점 x, y를 지나는 `직선 P`와 점 a, b를 지나는 `직선 Q`의 교차점이 T일 때, T가 점 x, y를 잇는 `선분 U` 위에 있으면서 동시에 점 a, b를 잇는 `선분 S` 위에 있으면 교차한다"** 라는 풀이다. 즉 선분을 직선으로 연장한 뒤 교차점을 찾고, 해당 교차점이 선분 위에 있는지 확인하는 방식이였다.

#### 해결 알고리즘 상세
풀이 방식에 대한 로직은 간단했다. 점 x, y를 지나는 `직선 P의 기울기 g`는 `y의 증가량 / x의 증가량 = (y2 - y1) / (x2 - x1)` 이고, `y 절편 i`는 `y = mx + b, b = y1 - (y2 - y1) / (x2 - x1) * x1` 가 된다. 
위 공식을 통해 `직선 P`와 `직선 Q`의 기울기와 절편을 구했다면 해당 두 공식의 교차점을 찾으면 된다. `P = Q`가 되는 점을 찾으면 되기 때문에 `P = mx + a = nx + b = Q` 라고 공식을 세우고 각각 기울기와 절편을 대입한 뒤, 연립 방정식으로 식을 풀면 `P = Q` 가 되는 `직선의 교차점 T`를 구할 수 있다.
`교차점 T`를 구했으니 이제 선분 상에 있는지만 확인하면 된다. `교차점 T`는 `직선 P, Q` 상에 있는게 자명하니 x, y 축의 값 중 하나만 비교해 주면 되겠다고 판단했다. 그렇게 T가 `선분 S, U` 상에 있는 것만 확인하면 교차 판단 알고리즘의 완성이였다. 

1. 선분을 연장해 직선을 긋기
2. 직선의 교차점 찾기
3. 교차점이 선분 상에 존재하는지 여부 확인하기

여기까진 문제가 없었다.

---
#### 1️⃣ 첫번째 위기
1%에서 마구마구 틀렸다. 생각해보니 **직선의 기울기가 0(x축과 평행) 이거나 무한(y축과 평행)** 일 수도 있겠다 싶었다. 이 부분을 별도로 처리해줘야하는데 이게 생각보다 매우 어려웠다. 우선 **직선의 기울기 값에 0, INF 값을 넣는 것으로 해결**해봤다.

---
#### 2️⃣ 두번째 위기
여전히 1%에서 오르질 않았다. 정답의 경우의 수가 1, 0 뿐인걸 감안하면 찍어도 1/2 확률인데 1%에서 멈춘다는건 운도 지지리 없다는 이야기겠다. 
**직선이 축과 평행한 경우는 연산을 별도로 진행할 필요**가 있었다. Line 객체에 `bool isZero, isInf` 변수를 두어 직선의 기울기가 0인 경우와 무한인 경우를 따로 표기하고, 교차점을 구할 때 경우의 수를 전부 구현했다. 한 직선의 기울기가 0이거나 무한인 경우에 기울기 값 혹은 절편 값이 이상해지기 때문에 기존의 연립 방정식 대로 하면 이상한 값이 나온다.
따라서 **한 직선이 기울기가 0이거나 무한인 경우에 해당 직선의 y절편 혹은 x 절편의 값을 취해 해당 값으로 연립방정식을 해결**했다.

---
#### 3️⃣ 세번째 위기
아마 이 때 3%까지 올랐던 것 같다. 기쁘긴 했는데 또 뭐가 문젠지 한참 헤매다가 **직선이 평행할 수도 있겠다**는 생각을 했다. 그래서 **기울기를 비교해 기울기가 같은 경우 절편을 비교해 절편이 같다면 같은 직선 상에 있다고 판단**했다.

---
#### 4️⃣ 네번째 위기
전혀 해결되지 않았다. 왜일까 고민해봤는데 **"실수 연산의 오차가 있는 경우"** 가 있을 수 있겠다 싶었다. 그래서 기울기나 절편을 비교할 떄 `P.gradient == Q.gradient` 하고 쓰던걸 `abs(P.gradient - Q.gradient) < ERR_RANGE` (ERR_RANGE = 0.001f) 로 오차 범위에 대해 허용했다.

---
#### 5️⃣ 다섯번째 위기
후 🚬  너무 답답했다... 그래도 조금 고민하다가 생각난게 **한 점에서 만나는 것도 선분이 교차한다고 판단**한다는 부분이 기억나서 직선의 두 점끼리 총 **4개의 점의 위치를 서로 비교**했다.

---
#### 6️⃣ 여섯번째 위기
🚬 🚬  3번째 위기에서 해결했던 평행한 직선의 만나는 여부에서 **직선은 평행하지만 범위가 달라 서로 만나지 않는 직선**도 있었다. 이 부분을 각 선분의 범위가 겹치는 경우를 찾아 예외처리했다.


너무 길어질 것 같아서 이 뒤는 조금 정리해서 적도록 하겠다.
- **직선이 평행할 때 서로 만나지 않는 선분** 에 대한 예외처리에서 일부분이 겹치는 선분은 잘 잡지만 완전 포함해버리는 직선에 대해 처리하지 못했다. 이 부분을 처리했다.
- **기울기가 0이거나 무한이면서 평행한 경우**도 있었다. 이 때는 **y 절편**만 비교하면 안되기 때문에 기울기에 따라 각각 `y 절편`, `x 절편`을 비교했다.
- 각 점의 위치의 범위가 `-1,000,000 ~ 1,000,000` 이기 때문에 연산하다가 `1,000,000 ^ 4` 까지 갈 수도 있겠다고 생각을 했다 (근거는 없었고 단순 추측이였다). `float` 를 `double` 로 선언했다. 
- 기존의 직선 범위를 비교할 때를 대비해 점 x, y를 잡을 때 각 점의 x 값이 오름차순이 되게 정렬했다. 당연한 이야기지만 y 값은 정렬되지 않는데 생각없이 y도 정렬된 것 처럼 사용하고 있었다. **y 값을 사용할 때 큰 값과 작은 값을 다시 구해 해결**했다.
- 오차 범위 `ERR_RANGE` 값을 0.001f 로 사용중이였는데 적당하지 못했다. 여러 시행착오를 통해 0.0000001f 가 적절하다는 것을 알았다. (근데 오차 범위에 따라 결과가 다르게 나오는거 보면 멀쩡한 풀이는 아니였던 것 같다.)
- 한 직선의 기울기가 0이고 한 직선의 기울기가 무한일 때 교차점을 예외처리해서 구해야했다. 각 직선의 y 절편, x 절편의 값을 가지고 예외처리 해줬다. 

말고도 세세하게 다양한 부분에 대해 해결책을 수립했었다. 하도 틀렸습니다 퍼센테이지가 들쑥날쑥해 수많은 해결책 중에 어떤 해결책이 효과가 있었고 어떤 해결책이 효과가 없었는지는 잘 모르겠다. 

## 📚 새롭게 알게된 내용
예외처리 해야할 경우의 수가 매우매우매우 많은 문제였다. 진짜 너무 화나는 문제였지만 모든 예외에 대해 하나하나 처리하다보니 해결해서 진짜진짜 너무 기뻤다.
예외의 경우의 수를 좀 더 많이 생각해보고, 테스트 케이스를 짤 필요가 있겠구나 느낀 문제였다.
