### PR TITLE
17-seongwon030

### DIFF
--- a/seongwon030/최소스패닝트리/최소스패닝트리.py
+++ b/seongwon030/최소스패닝트리/최소스패닝트리.py
@@ -1,0 +1,30 @@
+import sys
+
+input = sys.stdin.readline
+
+V,E = map(int,input().split())
+root = [i for i in range(V+1)]
+edge = [] # 간선리스트
+for i in range(E): 
+  edge.append(list(map(int,input().split())))
+
+# 비용을 기준으로 오름차순
+edge.sort(key=lambda x:x[2])
+
+def find(x):
+  if x!=root[x]:
+    root[x] = find(root[x])
+  return root[x]
+
+ans = 0 
+for a,b,c in edge:
+  aRoot = find(a)
+  bRoot = find(b)
+  if aRoot != bRoot:
+    if aRoot > bRoot:
+      root[aRoot] = bRoot
+    else:
+      root[bRoot] = aRoot
+    ans += c
+
+print(ans) 


### PR DESCRIPTION
## 🔗 문제 링크
[최소스패닝트리](https://www.acmicpc.net/problem/1197)

## ✔️ 소요된 시간
1시간 30분

## ✨ 수도 코드
> 첫 알고리즘 블로그

## 크루스칼 알고리즘

 가중치가 높은 간선을 제거하면서 최소 비용 신장 트리를 만드는 알고리즘

### 순서
![](https://velog.velcdn.com/images/seongwon__105/post/c18906c2-8b9c-462e-901f-6a0287f111c3/image.png)

### 예시
![](https://velog.velcdn.com/images/seongwon__105/post/94a4681c-d978-4931-bd02-a836e14e918d/image.png)

0. 초기 상태는 그래프의 가중치를 따라 내림차순으로 정렬한다.

![](https://velog.velcdn.com/images/seongwon__105/post/0469634d-6250-4b81-af8a-7d1d306c9946/image.png)
1. 가장 높은 가중치의 간선을 제거한다. 
=> 가중치가 17인 간선(A,C) 제거

![](https://velog.velcdn.com/images/seongwon__105/post/fa67a1b1-5493-4516-95d7-5eaee52de931/image.png)
2. 다음으로 높은 가중치의 간선을 제거한다.
=> 가중치가 14인 간선(F,G)제거 

![](https://velog.velcdn.com/images/seongwon__105/post/c3f1c1d2-e353-4a51-bb19-40a0539264d9/image.png)
3. 남은 간선 중 가중치가 가장 높은 간선 (B,G)를 제거한다.
![](https://velog.velcdn.com/images/seongwon__105/post/4031164f-f565-4ac2-adb8-8f33072abf2c/image.png)
4. 남은 간선 중 가중치가 가장 높은 간선 (C,E)를 제거한다.
![](https://velog.velcdn.com/images/seongwon__105/post/d1eb5b82-45b5-4928-9bf6-35d972e2e389/image.png)
5.남은 간선 중 가중치가 가장 높은 간선 (D,E)를 제거하면 그래프가 분리되어 단절 그래프가 된다. 그 다음으로 높은 가중치의 간선 (C,F)를 제거한다. 하지만 (C,F)를 제거하면 정점 C가 분리되므로 제거할 수 없다. 그러므로 다음으로 가중치가 높은 간선 (A,D)를 제거한다.
![](https://velog.velcdn.com/images/seongwon__105/post/4d16c9fe-4ecb-4faf-9c8e-f7250d78cb44/image.png)
6. 현재 남은 간선 수가 6개이므로 정점 7개, 간선 6개로 알고리즘 수행을 종료하면 신장 트리가 완성된다.


```python 
V,E = map(int,input().split())
root = [i for i in range(V+1)]
edge = [] # 간선리스트
for i in range(E): 
  edge.append(list(map(int,input().split())))

# 비용을 기준으로 오름차순
edge.sort(key=lambda x:x[2])

def find(x):
  if x!=root[x]:
    root[x] = find(root[x])
  return root[x]

ans = 0 
for a,b,c in edge:
  aRoot = find(a)
  bRoot = find(b)
  if aRoot != bRoot:
    if aRoot > bRoot:
      root[aRoot] = bRoot
    else:
      root[bRoot] = aRoot
    ans += c

print(ans) 
```

### find함수
주어진 노드 x의 최상위 부모(루트노드)를 찾는다. 경로 압축을 통해 트리의 높이를 줄이는 역할을 한다.

### 크루스칼을 이용한 MST
- 간선 리스트를 순회하며, 각 간선이 두 정점(a,b)를 연결한다. 각 정점의 부모 노드를 찾고, 부모 노드가 다르면 두 노드를 합친다. 이때 가중치 c를 ans에 더한다.
- 두 정점의 부모가 다르면, 사이클을 생성하지 않으므로 간선을 MST에 포함시킨다.
- 큰 root값을 작은 root값으로 만드는 건 큰 가중치의 간선부터 삭제하는 크루스칼의 특징을 보여준다.
