### PR TITLE
18-seongwon030

### DIFF
--- a/seongwon030/최소스패닝트리/정복자.py
+++ b/seongwon030/최소스패닝트리/정복자.py
@@ -1,0 +1,35 @@
+import collections
+import sys
+from heapq import heappop, heappush
+
+input = sys.stdin.readline
+
+N,M,T = map(int,input().split())
+graph = collections.defaultdict(list)
+answer = 0
+conquer_cost = 0
+
+for _ in range(M):
+    a,b,c = map(int,input().split())
+    graph[a].append((b,c))
+    graph[b].append((a,c))
+
+visited=[False for _ in range(N+1)]
+heap=[(0,1)]
+
+while heap:
+    cost,node = heappop(heap) # 힙에서 최소비용 간선 꺼냄
+
+    if not visited[node]: # 해당 노드 방문되지 않았다면 방문처리
+        visited[node]=True
+        answer += (cost + conquer_cost)  # answer에 현재 간선 비용과 T의 합을 더해줌
+
+        if node!=1: # 첫 번째 노드 아니면, 정복비용 T 증가 
+            conquer_cost += T
+
+        for next_node,next_cost in graph[node]: # 다음 노드 탐색하여 힙에 넣기 
+            if not visited[next_node]:
+                heappush(heap,(next_cost,next_node))
+
+
+print(answer)


### PR DESCRIPTION
## 🔗 문제 링크
[정복자](https://www.acmicpc.net/problem/14950)

## ✔️ 소요된 시간
1시간

## ✨ 수도 코드

<details>
<summary>문제</summary>

## 문제
서강 나라는 N개의 도시와 M개의 도로로 이루어졌다. 모든 도시의 쌍에는 그 도시를 연결하는 도로로 구성된 경로가 있다. 각 도로는 양방향 도로이며, 각 도로는 사용하는데 필요한 비용이 존재한다. 각각 도시는 1번부터 N번까지 번호가 붙여져 있다. 그 중에서 1번 도시의 군주 박건은 모든 도시를 정복하고 싶어한다.

처음 점거하고 있는 도시는 1번 도시 뿐이다. 만약 특정 도시 B를 정복하고 싶다면, B와 도로로 연결된 도시들 중에서 적어도 하나를 정복하고 있어야 한다. 조건을 만족하는 도시 중에서 하나인 A를 선택하면, B를 정복하는 과정에서 A와 B를 연결하는 도로의 비용이 소모된다. 박건은 한번에 하나의 도시만 정복을 시도하고 언제나 성공한다. 한 번 도시가 정복되면, 모든 도시는 경계를 하게 되기 때문에 모든 도로의 비용이 t만큼 증가하게 된다. 한 번 정복한 도시는 다시 정복하지 않는다.

이때 박건이 모든 도시를 정복하는데 사용되는 최소 비용을 구하시오.

## 입력
첫째 줄에 도시의 개수 N과 도로의 개수 M과 한번 정복할 때마다 증가하는 도로의 비용 t가 주어진다. N은 10000보다 작거나 같은 자연수이고, M은 30000보다 작거나 같은 자연수이다. t는 10이하의 자연수이다.

M개의 줄에는 도로를 나타내는 세 자연수 A, B, C가 주어진다. A와 B사이에 비용이 C인 도로가 있다는 뜻이다. A와 B는 N이하의 서로 다른 자연수이다. C는 10000 이하의 자연수이다.
</details>

### 첫번째 풀이
<code>크루스칼</code> 알고리즘으로 진행했을 때

```python 
import sys
input = sys.stdin.readline

n,m,t = map(int,input().split())
root = [i for i in range(n+1)]
edge = [] # 간선리스트

for i in range(m):
  edge.append(list(map(int,input().split())))

# 비용을 기준으로 오름차순
edge.sort(key=lambda x:x[2])

def find(x):
  if x!=root[x]:
    root[x] = find(root[x])
  return root[x]

ans = 0
for a,b,c in edge:
  aRoot = find(a)
  bRoot = find(b)
  if aRoot != bRoot:
    if aRoot > bRoot:
      root[aRoot] = bRoot
    else:
      root[bRoot] = aRoot
    ans += c

    for j in range(m):
      edge[j][2] += t

print(ans)
```

되긴 되는데.. python으로는 시간초과가 나고 pypy로 해야 겨우 통과되었다. 왜 그런지 봤더니 크루스칼은 모든 경로를 탐색하는데 문제에선 하나의 정점을 방문했다면 다시 방문할 필요 없도록 해야 한다. 방문여부 리스트를 추가한다 해도 크루스칼은 의미가 없으니 다른 방법을 찾아봤다.

### 두번째 풀이

```python
import collections
import sys
from heapq import heappop, heappush

input = sys.stdin.readline

N,M,T = map(int,input().split())
graph = collections.defaultdict(list)
answer = 0
conquer_cost = 0

for _ in range(M):
    a,b,c = map(int,input().split())
    graph[a].append((b,c))
    graph[b].append((a,c))

visited=[False for _ in range(N+1)]
heap=[(0,1)]

while heap:
    cost,node = heappop(heap) # 힙에서 최소비용 간선 꺼냄

    if not visited[node]: # 해당 노드 방문되지 않았다면 방문처리
        visited[node]=True
        answer += (cost + conquer_cost)  # answer에 현재 간선 비용과 T의 합을 더해줌

        if node!=1: # 첫 번째 노드 아니면, 정복비용 T 증가 
            conquer_cost += T

        for next_node,next_cost in graph[node]: # 다음 노드 탐색하여 힙에 넣기 
            if not visited[next_node]:
                heappush(heap,(next_cost,next_node))


print(answer)
```
찾아보니 <code>프림</code> 알고리즘이라는 게 있었다. 크루스칼과는 다르게 최소 비용인 정점을 방문하면서 직접 최소 신장 트리를 만든다. 크루스칼은 이미 연결되어 있는 트리에서 하나씩 삭제하는 식이라면 프림은 만들어 나가는 식이기 때문에 훨씬 효율적이었다. 

1. 파이썬의 <code>heap</code> 모듈을 사용하면 항상 <code>최소비용</code>의 간선을 <code>heappop</code>으로 꺼낼 수 있다.
2. 정점을 방문할 때마다 <code>전체 정복자 비용 변수</code>에 T를 더해준다.
3. 모든 정점을 방문했다면 종료한다.
<img width="1152" alt="스크린샷 2024-07-08 10 07 48" src="https://github.com/AlgoLeadMe/AlgoLeadMe-8/assets/105052068/327e875c-92f2-4d03-80e3-6f2a2620103f">



## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
어떤 경우에 크루스칼 또는 프림을 사용해야 하는지 감을 잡게 하는 문제였습니다.