### PR TITLE
19-seongwon030

### DIFF
--- a/seongwon030/최소스패닝트리/전력난.py
+++ b/seongwon030/최소스패닝트리/전력난.py
@@ -1,0 +1,35 @@
+import sys
+input = sys.stdin.readline
+
+def find(x):
+  if x!=root[x]:
+    root[x] = find(root[x])
+  return root[x]
+
+
+while True:
+  V,E = map(int,input().split())
+  if V==0 and E==0:
+    break
+  root = [i for i in range(V+1)]
+  edge = [] # 간선리스트
+  for i in range(E):
+    a,b,c = map(int,input().split())
+    edge.append((a,b,c))
+
+  # 비용을 기준으로 오름차순
+  edge.sort(key=lambda x:x[2])
+
+  ans = 0
+  for a,b,c in edge:
+    aRoot = find(a)
+    bRoot = find(b)
+    if aRoot != bRoot:
+      if aRoot < bRoot:
+        root[bRoot] = aRoot
+      else:
+        root[aRoot] = bRoot
+    else:
+      ans+=c 
+
+  print(ans)


### PR DESCRIPTION
## 🔗 문제 링크
[전력난](https://www.acmicpc.net/problem/6497)

## ✔️ 소요된 시간
2시간

## ✨ 수도 코드

### 루트노드 찾기
```python
def find(x):
  if x!=root[x]:
    root[x] = find(root[x])
  return root[x]
```

### 유니온 파인드로 두 개의 노드 합치기
```python

def union(x,y):
  x,y = find(x),find(y)
  if x<y:
    root[y] = x
  else:
    root[x] = y
```
위 두가지 함수를 이용해서 문제를 풀었습니다. 사실 저번에 푼 문제를 비슷했는데 좀 헤맸습니다. 최소신장트리 비용이 아니라 <code>가로등의 불을 아낀 비용</code>을 계산해야 하는 문제였습니다.

```python
for a,b,c in edge:
    aRoot = find(a)
    bRoot = find(b)
    if aRoot != bRoot: # 이어지지 않음 (사이클이 없다)
      union(aRoot,bRoot)
    else: # 이어짐 (절약할 수 있다)
      ans+=c 
```
1. <code>사이클이 없는</code> 경우 이어지지 않았으므로 두 정점을 이어줍니다.
2. <code>사이클이 있다면</code> 절약할 수 있기 때문에 그대로 비용을 더해줍니다.

## 📚 새롭게 알게된 내용
문제를 잘 읽자.