### PR TITLE
20-yuyu0830

### DIFF
--- a/yuyu0830/LIS/14003.cpp
+++ b/yuyu0830/LIS/14003.cpp
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <map>
+#include <vector>
+
+#define NUM 1000010
+#define fastio ios_base::sync_with_stdio(false); cin.tie(nullptr); cout.tie(nullptr);
+
+using namespace std;
+
+typedef pair<int, int> ii;
+
+int cnt = 0;
+int arr[NUM] = {0, };
+vector<ii> v[NUM];
+
+// 이진 탐색
+int bs(int value) {
+    int low = 0, mid, high = cnt;
+
+    while (low <= high) {
+        mid = (low + high) / 2;
+
+        if (v[mid].back().first == value)
+            return -1;
+
+        if (value < v[mid].back().first) high = mid - 1;
+        else low = mid + 1;
+    }
+
+    return mid + (value < v[mid].back().first ? -1 : 0);
+}
+
+int main() {
+    fastio;
+
+    int n; cin >> n;
+    
+    for (int i = 0; i < n; i++)  {
+        cin >> arr[i];
+    }
+
+    // 오류 대비 초기값
+    v[0].push_back(make_pair(-1000000001, 0));
+
+    for (int i = 0; i < n; i++) {
+        int l = arr[i];
+
+        if (l > v[cnt].back().first) {
+            // 만약 가장 큰 값이면 맨 앞에 두기
+            v[++cnt].push_back(make_pair(l, v[cnt - 1].size()));
+            continue;
+        } 
+        
+        // 중간에 들어가야하는 값이면 앞의 요소가 뭔지 저장한 뒤에 벡터에 보관
+        int t = bs(l) + 1;
+        if (t == 0) continue;
+
+        v[t].push_back(make_pair(l < v[t].back().first ? l : v[t].back().first, v[t - 1].size()));
+    }
+
+    printf("%d\n", cnt);
+
+    // 가장 끝 요소부터 역순으로 순서 찾아오기
+    vector<int> ans;
+    ii tmp = v[cnt--][0];
+    
+    do {
+        ans.push_back(tmp.first);
+        tmp = v[cnt][tmp.second - 1];
+    } while(cnt--);
+
+    while (!ans.empty()) {
+        printf("%d ", ans.back());
+        ans.pop_back();
+    }
+}

--- a/yuyu0830/README.md
+++ b/yuyu0830/README.md
@@ -17,5 +17,5 @@
 | 13차시| 2024.05.21 |  LIS  | [가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015)  | - |
 | 15차시| 2024.06.01 |  기하  | [다각형의 면적](https://www.acmicpc.net/problem/2166)  | - |
 | 16차시 | 2024.06.04 |  MST  | [별자리 만들기](https://www.acmicpc.net/problem/4386)  | - |
-| 20차시 | 2024.07.22 |  LIS  | [가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/4386)  | - |
+| 20차시 | 2024.07.22 |  LIS  | [가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/14003)  | - |
 ---

--- a/yuyu0830/README.md
+++ b/yuyu0830/README.md
@@ -16,5 +16,6 @@
 | 12차시| 2024.05.13 |  해시  | [두 배열의 합](https://www.acmicpc.net/problem/2143)  | - |
 | 13차시| 2024.05.21 |  LIS  | [가장 긴 증가하는 부분 수열 2](https://www.acmicpc.net/problem/12015)  | - |
 | 15차시| 2024.06.01 |  기하  | [다각형의 면적](https://www.acmicpc.net/problem/2166)  | - |
-| 16차시 | 2024.06.04 |  별자리 만들기  | [별자리 만들기](https://www.acmicpc.net/problem/4386)  | - |
+| 16차시 | 2024.06.04 |  MST  | [별자리 만들기](https://www.acmicpc.net/problem/4386)  | - |
+| 20차시 | 2024.07.22 |  LIS  | [가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/4386)  | - |
 ---


### PR DESCRIPTION
## 🔗 문제 링크
[가장 긴 증가하는 부분 수열 5](https://www.acmicpc.net/problem/14003)

## ✔️ 소요된 시간
아주 오래... 틈틈히 풀어서 체감상 2주..? 모으면 한 3~4시간

## ✨ 수도 코드
### ❓ 문제
`수열 A` 가 주어진다. 가장 긴 증가하는 수열, 즉 LIS의 크기를 구한 뒤 LIS를 하나 출력하자!

### 조건
- 수열 A의 크기 N : (1 ≤ N ≤ 1,000,000)
- 수열 A를 이루고 있는 Ai : (-1,000,000,000 ≤ Ai ≤ 1,000,000,000)

---

### ❗ 풀이
![image](https://github.com/user-attachments/assets/b12281fc-b5bc-4df7-9efe-addd638e36d0)
보다시피 조건을 조금씩 바꿔서 꿀빨 수 있는 문제 라인업이다. 5번 문제는 지금까지 조건을 모두 합쳤다. 각 조건은 아래와 같다.
<br>

1. `수열의 크기`가 **1,000,000** 이다.
  - LIS 배열 탐색 시간을 O(n log n) 을 만들어야 한다. ([이전 풀이 참고](https://github.com/AlgoLeadMe/AlgoLeadMe-8/pull/52))
2. `Ai`가 **음수를 포함**한다.
  - 배열의 값을 최저한도로 초기화 해두거나 vector를 써서 빈 배열의 경우를 처리한다.
3. `Ai의 범위`가 **1,000,000,000** 까지 늘어난다.
  - 이진 탐색을 통해 탐색 시간도 O(n log n) 을 만들어야 한다.
4. `LIS`를 하나 출력해야한다.
  - 1번 조건을 위해 배열 탐색 시간을 O(n log n) 으로 만들면 값을 항상 갱신하기 때문에 LIS를 만들기 위해서는 추가적인 방법이 필요하다.
<br>

1, 2, 3번 조건은 크게 어렵지 않으니 4번 조건 해결만 보자

문제가 되는 상황은 다음과 같은 상황이다. 

![image](https://github.com/user-attachments/assets/b215ee76-ac4d-4f37-9af1-c79af548ee0a)
`수열 A`가 1, 3, 4, 5, 2 가 주어진 경우 아래와 같이 동작한다.


LIS 배열이 비어있으니 1번으로 이동
![image](https://github.com/user-attachments/assets/d60ec11d-e9ff-421f-baaa-8ed17081d707)

LIS 배열의 가장 큰 값보다 현재 비교하는 값이 크기 때문에 가장 큰 값의 index + 1로 이동
![image](https://github.com/user-attachments/assets/7e60f13e-8cb4-4cca-8384-329ceeb7587a)

4, 5도 마찬가지로 이동
![image](https://github.com/user-attachments/assets/6a3925fe-0885-43b6-98da-0a45d422336d)

2는 1보단 크지만 3보단 작기 때문에 LIS[2]를 갱신
![image](https://github.com/user-attachments/assets/f920f3b8-4602-4f45-987a-365ec3cd55ec)
![image](https://github.com/user-attachments/assets/a084c3ff-5a35-48f2-a858-ab7f87ab3933)

결과 LIS의 최대 길이인 4는 맟출 수 있지만 수열 (1, 2, 4, 5) 는 `수열 A의 LIS`가 될 수 없다. 항상 값을 갱신하기 때문에 생기는 문제다.

---

#### 1️⃣  첫번째 풀이
정답이 될 수 있는 LIS `배열 ans` 와 값을 비교해 각 정수의 위치를 찾는 `배열 m` 을 따로 두어 **최대 값을 갱신할 때마다 현재의 `ans 배열` 을 갱신하는 방식**이다. 이렇게 하면 최대 값이 갱신될 때만 ans 배열이 갱신되기 때문에 최대 값 갱신 이후의 갱신에 의한 값 덮어쓰기는 없어진다.

하지만 최대 값이 아닌 중간 값이 갱신되는 과정에서 순서가 섞일 수 있기 때문에 결과적으로 틀린 풀이가 되었다.
<br>

#### 2️⃣ 두번째 풀이
중간 값도 갱신될 때마다 값을 저장한다. `2차원 vector v`를 통해 각 값 별로 갱신될 때마다 값을 같이 갱신하는 방식이다. m[i]를 갱신하면 v[i] = v[i - 1] + Ai 로 각 인덱스마다 벡터로 저장하기 때문에 중간 값이 갱신 되어도 덮어쓰기에 의해 LIS가 변질될 가능성은 없다.

![image](https://github.com/user-attachments/assets/34296776-27dc-4bda-9bc4-c3b85eb771fa)
하지만 수열의 크기가 크기인 만큼 이론상 최대 `((n / 2) * ((n / 2) - 1)) / 2` 의 크기가 생길 수가 있다... 어마어마한 메모리 낭비가 된다.
메모리 초과는 의도해서 띄운 걸 제외하면 처음 띄워본 것 같다...
<br>

#### 3️⃣ 세번째 풀이
한참 고민하면서 노트에 직접 적어보다가 문득 항상 LIS 전체를 저장할 필요는 없다는 생각이 들었다. 각 값을 갱신할 때 버리지 말고 vector를 통해 저장하면서 갱신하고, `Ai` 를 갱신할 때 v[t] 에 push 해야한다면 v[t - 1]의 m번째 요소보다 작다는 걸 pair<int, int> 형태로 저장해두면 나중에 역순으로 찾아갈 수 있다!

![image](https://github.com/user-attachments/assets/85051bfe-028b-47ec-a7de-b1f333c777b6)
비어있기 때문에 1번, 앞의 요소중 비교할 것이 없기 때문에 0을 함께 저장한다.

![image](https://github.com/user-attachments/assets/8458040d-5f7d-4ab5-9429-8f2946a697ad)
3은 1보다 크기 때문에 index 2로 들어간다. 이 때, 이전 index의 가장 큰 값의 index를 저장해준다. 1이 0번에 있기 때문에 (3, 0)을 저장한다.

![image](https://github.com/user-attachments/assets/a91f533c-dd56-4f65-981d-57c38422fedc)
4, 5도 마찬가지로 진행한다.
<br>

이렇게 하면 2가 남는데, 2도 마찬가지로 index 2번에 (2, 0)으로 push 한다.
![image](https://github.com/user-attachments/assets/d7ff0d80-4184-42be-81c0-c3755804f1c9)

이제 가장 큰 수부터 역순으로 찾아간다. 앞의 값이 LIS에 들어갈 수, 뒤의 값이 이전 index에서 몇번째 값을 참고하면 되는지를 의미한다.

![image](https://github.com/user-attachments/assets/dbacd179-eb8f-4083-a571-304109882006)

5부터 역순으로 찾아가면 LIS (1, 3, 4, 5) 를 찾을 수 있다!

## 📚 새롭게 알게된 내용
역시 안될 때는 펜을 잡고 끄적여보자.
