### PR TITLE
27-seongwon030

### DIFF
--- a/seongwon030/다익스트라/최소비용 구하기2.py
+++ b/seongwon030/다익스트라/최소비용 구하기2.py
@@ -1,0 +1,51 @@
+import sys
+import heapq
+from collections import defaultdict
+
+input = sys.stdin.readline
+
+INF = int(1e9)
+n = int(input())
+m = int(input())
+graph = defaultdict(list)
+
+# 입력
+for _ in range(m):
+    a,b,c = map(int,input().split())
+    graph[a].append((b,c))
+
+v1,v2 = map(int,input().split())
+
+distance = [INF] * (n+1)
+prev_node = [0] * (n+1)
+# 데이크 스트라 알고리즘
+def di(start):
+    q = []
+    heapq.heappush(q, [0,start])
+    distance[start] = 0
+
+    while q:
+        dist, node = heapq.heappop(q)
+
+        if distance[node] < dist:
+            continue
+        for n,w in graph[node]:
+            cost = dist + w
+
+            if distance[n] > cost:
+                distance[n]= cost
+                prev_node[n] = node
+                heapq.heappush(q,[cost,n])
+
+di(v1)
+print(distance[v2])
+
+path = [v2]
+now = v2
+while now != v1:
+  now = prev_node[now]
+  path.append(now)
+
+path.reverse()
+print(len(path))
+print(' '.join(map(str,path)))


### PR DESCRIPTION
## 🔗 문제 링크
[최소비용구하기2](https://www.acmicpc.net/problem/11779)

## ✔️ 소요된 시간
2시간


### 문제 설명
정점과 간선 사이의 비용이 주어지고 출발 지점에서 도착 지점에 주어질 때, 출발 지점에서 도착 지점까지의 최소 비용, 최소 비용을 갖는 경로에 포함되어있는 도시의 개수를 출력한다. 출발 도시와 도착 도시도 포함한다.

## ✨ 수도 코드

해당 문제는 다익스트라 알고리즘으로 최소비용을 갱신하면서 최소비용을 구해야 합니다.
출력과정에서 이전 노드를 기록하고 출력하는데 애를 좀 먹었습니다.

### 다익스트라
```python
# 데이크 스트라 알고리즘
def di(start):
    q = []
    heapq.heappush(q, [0,start]) # 시작노드는 거리가 0 / 시작노드 번호
    distance[start] = 0 # 첫 노드 비용을 0으로 설정 

    while q:
      # dist 는 현재 노드까지 도달하는데 걸린 최소비용
      # node 는 현재 방문 중인 노드
        dist, node = heapq.heappop(q)

        if distance[node] < dist:  # 현재 꺼낸 거리가 기존 최단거리보다 크면 스킵
            continue
        for n,w in graph[node]: # 현재 노드의 인접 노드 탐색
            cost = dist + w # 가중치 더해서 새로운 거리를 계산

            if distance[n] > cost: # 기존 거리보다 짧으면 갱신
                distance[n]= cost  
                prev_node[n] = node  # 이전 노드를 기록
                heapq.heappush(q,[cost,n]) # 갱신된 인접 노드를 큐에 추가 
```
- 이전노드 기록은 <code>prev_node</code> 리스트에 저장해놓습니다.
- 다음 노드를 갱신하는 경우에만 기록합니다.

### 최단거리 
```python
di(v1)
print(distance[v2])
```
- 시작 지점인 <code>v1</code> 을 인자로 하여 다익스트라 함수를 실행 -> 출발노드에서 모든 노드까지의 최단거리를 계산
- 도착노드에 해당하는 <code>v2</code>까지의 거리를 구합니다

### 이전 도시들 
```python
path = [v2]
now = v2
while now != v1:
  now = prev_node[now]
  path.append(now)

path.reverse()
print(len(path))
print(' '.join(map(str,path)))
```
- <code>prev_node</code> 에는 <code>v2(도착 노드)까지의 도시 번호</code>가 저장되어 있습니다
-  <code>path</code> : 도착노드를 초기값으로 하는 리스트
- 이전 노드에서 출발노드가 나올때까지 <code>path</code>에 도시 번호들을 저장합니다 

